### PR TITLE
Parameterize topK

### DIFF
--- a/src/cmd/query.ts
+++ b/src/cmd/query.ts
@@ -28,10 +28,18 @@ const argv = yargs(hideBin(process.argv))
     default: false,
     demandOption: false,
   })
+  .option('topK', {
+    type: 'number',
+    description:
+      'The number of documents that will be fetched from the vector store and added to the context',
+    default: 3,
+    demandOption: false,
+  })
   .parseSync();
 
 query(getVectorStore(argv.store), {
   query: argv.query,
   model: argv.model,
   llmOnly: argv.llmOnly,
+  topK: argv.topK,
 });

--- a/src/indexing.ts
+++ b/src/indexing.ts
@@ -79,6 +79,8 @@ export async function indexWikipedia(vectorStore: VectorStore, term: string) {
 
   if (!success) {
     throw new Error(`Failed up write ${term}'s wikipedia entry to vector store`);
+  } else {
+    console.log(`Added ${success.length} vectors to ${vectorStore.name}.`);
   }
 }
 

--- a/src/query.ts
+++ b/src/query.ts
@@ -6,19 +6,18 @@ type QueryOptions = {
   query: string;
   model: string;
   llmOnly: boolean;
+  topK: number;
 };
 
 export async function query(vectorStore: VectorStore, options: QueryOptions) {
-  const query = options.query;
-  const model = options.model;
-  const llmOnly = options.llmOnly;
+  const { query, model, llmOnly, topK } = options;
 
   const prompt = ['Answer the question based on the markdown context below.'];
 
   if (llmOnly) {
     console.log(`Querying ${model} without additional context`);
   } else {
-    const { results, context } = await getContext(vectorStore, query);
+    const { results, context } = await getContext(vectorStore, query, topK);
 
     console.log(`Querying ${model} with additional context`);
     console.log(
@@ -44,11 +43,11 @@ export async function query(vectorStore: VectorStore, options: QueryOptions) {
   console.log(results[0].text?.trim());
 }
 
-async function getContext(vectorStore: VectorStore, query: string) {
+async function getContext(vectorStore: VectorStore, query: string, topK: number) {
   const embedding = await createEmbedding({ input: query });
 
   const results = await vectorStore.query({
-    topK: 3,
+    topK,
     embedding: embedding.data[0].embedding,
   });
 


### PR DESCRIPTION
Interestingly, I get different answers when I change it!
With k=1 it's totally wrong (even if it got the right doc). I immediately wanted to do what you said and debug the context.

```
npm run query -- --store=pinecone --query="What is cruise?" --topK=4

Cruise is an American self-driving car company headquartered in San Francisco, California.

npm run query -- --store=pinecone --query="What is cruise?" --topK=2

Cruise is an American self-driving car company headquartered in San Francisco, California. Founded in 2013 by Kyle Vogt and Dan Kan, Cruise tests and develops autonomous car technology. The company is a largely-autonomous subsidiary of General Motors.

npm run query -- --store=pinecone --query="What is cruise?" --topK=1

Cruise is a type of travel that is designed to be luxurious and comfortable.
```