### PR TITLE
Stricter enforcement of enum options

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ _Note that pgvector is limited to 2k dimensions max today._
 
 ```bash
 npm run vector_store:prepare -- --store=pinecone
-npm run vector_store:prepare -- --store=pg
 ```
 
 Prepare your vector store for use. The `store` argument is required and must be one of the supported stores.
@@ -35,7 +34,6 @@ Prepare your vector store for use. The `store` argument is required and must be 
 
 ```bash
 npm run vector_store:teardown -- --store=pinecone
-npm run vector_store:teardown -- --store=pg
 ```
 
 for pinecone: this tears the vector store down, i.e., deletes indexes. The `store` argument is required and must be one of the supported stores.
@@ -62,7 +60,7 @@ npm run vector_store:upload -- --store=pinecone --reader=fs --reader-options='{"
 npm run query -- --store=pinecone --query="When was the San Francisco Police Department founded?"
 ```
 
-The `store` argument is required and must be one of the supported stores: `['pinecone', 'chroma', 'pg']`
+The `store` argument is required and must be one of the supported stores.
 
 This performs the following actions:
 

--- a/src/cmd/query.ts
+++ b/src/cmd/query.ts
@@ -3,10 +3,11 @@ import { hideBin } from 'yargs/helpers';
 
 import { query } from '../query';
 import { getVectorStore } from './utils';
+import { SUPPORTED_VECTOR_STORES } from '../vector_stores';
 
 const argv = yargs(hideBin(process.argv))
   .option('store', {
-    type: 'string',
+    choices: SUPPORTED_VECTOR_STORES,
     description: 'The vector store',
     demandOption: true,
   })

--- a/src/cmd/utils.ts
+++ b/src/cmd/utils.ts
@@ -1,10 +1,15 @@
+import { read as fsRead } from '../readers/fs';
+import { read as wikipediaRead } from '../readers/wikipedia';
 import { Pinecone } from '../vector_stores/pinecone';
 import { Chroma } from '../vector_stores/chroma';
 import { PgVector } from '../vector_stores/pgvector';
 import { getEnv, getEnvOrThrow } from '../config';
 import { VectorStore } from '../types';
 
-export function getVectorStore(store: string): VectorStore {
+import type { SupportedReaders } from '../readers';
+import type { SupportedVectorStores } from '../vector_stores';
+
+export function getVectorStore(store: SupportedVectorStores): VectorStore {
   switch (store) {
     case 'chroma':
       return new Chroma({
@@ -18,12 +23,23 @@ export function getVectorStore(store: string): VectorStore {
         apiKey: getEnvOrThrow('PINECONE_API_KEY'),
         environment: getEnvOrThrow('PINECONE_ENVIRONMENT'),
       });
-    case 'pg':
+    case 'pgvector':
       return new PgVector({
         dsn: getEnvOrThrow('PG_DSN'),
         tableName: getEnvOrThrow('PG_TABLE_NAME'),
       });
     default:
       throw new Error(`Unrecognized store "${store}"`);
+  }
+}
+
+export function getReader(type: SupportedReaders) {
+  switch (type) {
+    case 'fs':
+      return fsRead;
+    case 'wikipedia':
+      return wikipediaRead;
+    default:
+      throw new Error(`Unsupported reader "${type}"`);
   }
 }

--- a/src/cmd/vector_store/prepare.ts
+++ b/src/cmd/vector_store/prepare.ts
@@ -4,11 +4,12 @@ import { hideBin } from 'yargs/helpers';
 import { prepare as prepareChroma } from '../../vector_stores/chroma';
 import { prepare as preparePinecone } from '../../vector_stores/pinecone';
 import { prepare as preparePg } from '../../vector_stores/pgvector';
+import { SUPPORTED_VECTOR_STORES, type SupportedVectorStores } from '../../vector_stores';
 import { getEnv, getEnvOrThrow } from '../../config';
 
 const argv = yargs(hideBin(process.argv))
   .option('store', {
-    type: 'string',
+    choices: SUPPORTED_VECTOR_STORES,
     description: 'The vector store',
     demandOption: true,
   })
@@ -16,7 +17,7 @@ const argv = yargs(hideBin(process.argv))
 
 prepare(argv.store);
 
-async function prepare(store: string) {
+async function prepare(store: SupportedVectorStores) {
   switch (store) {
     case 'chroma':
       return await prepareChroma({
@@ -30,7 +31,7 @@ async function prepare(store: string) {
         index: getEnvOrThrow('PINECONE_INDEX'),
         dimension: Number(getEnvOrThrow('PINECONE_INDEX_DIMENSION')),
       });
-    case 'pg':
+    case 'pgvector':
       return await preparePg({
         tableName: getEnvOrThrow('PG_TABLE_NAME'),
         dimension: Number(getEnvOrThrow('PG_VECTOR_DIMENSION')),

--- a/src/cmd/vector_store/teardown.ts
+++ b/src/cmd/vector_store/teardown.ts
@@ -5,10 +5,11 @@ import { getEnv, getEnvOrThrow } from '../../config';
 import { teardown as teardownChroma } from '../../vector_stores/chroma';
 import { teardown as teardownPinecone } from '../../vector_stores/pinecone';
 import { teardown as teardownPg } from '../../vector_stores/pgvector';
+import { SUPPORTED_VECTOR_STORES, type SupportedVectorStores } from '../../vector_stores';
 
 const argv = yargs(hideBin(process.argv))
   .option('store', {
-    type: 'string',
+    choices: SUPPORTED_VECTOR_STORES,
     description: 'The vector store',
     demandOption: true,
   })
@@ -16,7 +17,7 @@ const argv = yargs(hideBin(process.argv))
 
 teardown(argv.store);
 
-async function teardown(store: string) {
+async function teardown(store: SupportedVectorStores) {
   switch (store) {
     case 'chroma':
       return await teardownChroma({
@@ -29,7 +30,7 @@ async function teardown(store: string) {
         environment: getEnvOrThrow('PINECONE_ENVIRONMENT'),
         index: getEnvOrThrow('PINECONE_INDEX'),
       });
-    case 'pg':
+    case 'pgvector':
       return await teardownPg({
         tableName: getEnvOrThrow('PG_TABLE_NAME'),
         dsn: getEnvOrThrow('PG_DSN'),

--- a/src/cmd/vector_store/upload.ts
+++ b/src/cmd/vector_store/upload.ts
@@ -1,12 +1,13 @@
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import { index } from '../../indexing';
-import { getVectorStore } from '../utils';
-import { getReader, SUPPORTED_READERS } from '../../readers';
+import { getReader, getVectorStore } from '../utils';
+import { SUPPORTED_READERS } from '../../readers';
+import { SUPPORTED_VECTOR_STORES } from '../../vector_stores';
 
 const argv = yargs(hideBin(process.argv))
   .option('store', {
-    type: 'string',
+    choices: SUPPORTED_VECTOR_STORES,
     description: 'The vector store',
     demandOption: true,
   })

--- a/src/readers/fs.ts
+++ b/src/readers/fs.ts
@@ -8,6 +8,8 @@ import { chunk as chunkText } from '../chunking/text';
 import { generateId, getPathRelativeToDirectory } from '../utils';
 import type { Document } from '../types';
 
+export const NAME = 'fs' as const;
+
 export async function* read(options: { path: string; glob?: string }) {
   const path = Path.resolve(process.cwd(), options.path);
 

--- a/src/readers/index.ts
+++ b/src/readers/index.ts
@@ -1,16 +1,5 @@
-import { read as fsRead } from './fs';
-import { read as wikipediaRead } from './wikipedia';
+import { NAME as fs } from './fs';
+import { NAME as wikipedia } from './wikipedia';
 
-export const SUPPORTED_READERS = ['fs', 'wikipedia'] as const;
+export const SUPPORTED_READERS = [fs, wikipedia] as const;
 export type SupportedReaders = (typeof SUPPORTED_READERS)[number];
-
-export function getReader(type: SupportedReaders) {
-  switch (type) {
-    case 'fs':
-      return fsRead;
-    case 'wikipedia':
-      return wikipediaRead;
-    default:
-      throw new Error(`Unsupported reader "${type}"`);
-  }
-}

--- a/src/readers/wikipedia.ts
+++ b/src/readers/wikipedia.ts
@@ -2,6 +2,8 @@ import { chunk as chunkText } from '../chunking/text';
 import { generateId } from '../utils';
 import type { Document } from '../types';
 
+export const NAME = 'wikipedia' as const;
+
 export async function* read(options: { term: string }) {
   const term = options.term;
 

--- a/src/vector_stores/chroma.ts
+++ b/src/vector_stores/chroma.ts
@@ -22,11 +22,13 @@ export async function teardown(options: { collection: string; path?: string }) {
   });
 }
 
+export const NAME = 'chroma' as const;
+
 export class Chroma implements VectorStore {
   private client: ChromaClient;
   private collection: Collection | null = null;
   private initialized: Promise<void>;
-  name: string = 'chroma';
+  name = NAME;
 
   constructor(options: { collection: string | Collection; path?: string; client?: ChromaClient }) {
     this.client =

--- a/src/vector_stores/index.ts
+++ b/src/vector_stores/index.ts
@@ -1,0 +1,6 @@
+import { NAME as chroma } from './chroma';
+import { NAME as pgvector } from './pgvector';
+import { NAME as pinecone } from './pinecone';
+
+export const SUPPORTED_VECTOR_STORES = [chroma, pgvector, pinecone] as const;
+export type SupportedVectorStores = (typeof SUPPORTED_VECTOR_STORES)[number];

--- a/src/vector_stores/pgvector.ts
+++ b/src/vector_stores/pgvector.ts
@@ -34,10 +34,12 @@ export async function teardown(options: { tableName: string; dsn: string }) {
   await db.none(`DROP TABLE IF EXISTS ${name};`);
 }
 
+export const NAME = 'pgvector' as const;
+
 export class PgVector implements VectorStore {
   private db: pgpromise.IDatabase<{}>;
   private tableName: string;
-  name: string = 'pgvector';
+  name = NAME;
 
   constructor(options: { dsn: string; tableName: string }) {
     this.db = getDB(options.dsn);

--- a/src/vector_stores/pinecone.ts
+++ b/src/vector_stores/pinecone.ts
@@ -38,12 +38,14 @@ export async function teardown(options: { apiKey: string; environment: string; i
   });
 }
 
+export const NAME = 'pinecone' as const;
+
 export class Pinecone implements VectorStore {
   private index: string;
   private namespace: string;
   private client: PineconeClient;
   private initialized: Promise<void>;
-  name: string = 'pinecone';
+  name = NAME;
 
   constructor(options: {
     index: string;


### PR DESCRIPTION
This creates a stricter pattern when dealing with choices for things like vector stores, readers, and more in the future.

These stricter types are tied into the CLI, so that it will A) tell you what choices are available if you use the help menu and B) yell at you if you chose an invalid option with a nice error message. For example:

```
❯ npm run vector_store:teardown -- --store=notastore

Options:
  --help     Show help                                                 [boolean]
  --version  Show version number                                       [boolean]
  --store    The vector store
                          [required] [choices: "chroma", "pgvector", "pinecone"]

Invalid values:
  Argument: store, Given: "notastore", Choices: "chroma", "pgvector", "pinecone"

```