### PR TITLE
Initial support for metadata filtering: exact term match.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,15 @@ _Note: Only OpenAI models are supported right now_
 
 You can query the LLM directly using the `--llm-only` flag.
 
+This allows you to see how the model performs with and without additional context from the vector store.
+
 ```bash
 npm run query -- --store=pinecone --query="How do I do X where X is something in my documents?" --llm-only
 ```
 
-This allows you to see how the model performs with and without additional context from the vector store.
+You can filter metadata when querying. Currently, we only support exact match, so to match documents uploaded with the term 'San Francisco' for example:
+
+```
+npm run query -- --store=pgvector --query="How do I do X where X is something in my documents?" --filterTerm='San Francisco' --topK=3
+
+```

--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ If you plan on using postgres + pgvector. You need to have a postgres URL, with 
 
 _Note that pgvector is limited to 2k dimensions max today._
 
+### Setting up chroma
+
+You'll need to follow their instructions if you want to run it locally:
+
+```bash
+git clone https://github.com/chroma-core/chroma.git
+cd chroma
+docker-compose up -d --build
+```
+
 ## Usage
 
 ### Prepare the vector store

--- a/src/cmd/query.ts
+++ b/src/cmd/query.ts
@@ -36,6 +36,12 @@ const argv = yargs(hideBin(process.argv))
     default: 3,
     demandOption: false,
   })
+  .option('filterTerm', {
+    type: 'string',
+    description: 'Filter vectors with the given "term" key in metadata',
+    default: '',
+    demandOption: false,
+  })
   .parseSync();
 
 query(getVectorStore(argv.store), {
@@ -43,4 +49,5 @@ query(getVectorStore(argv.store), {
   model: argv.model,
   llmOnly: argv.llmOnly,
   topK: argv.topK,
+  filterTerm: argv.filterTerm,
 });

--- a/src/query.ts
+++ b/src/query.ts
@@ -7,17 +7,20 @@ type QueryOptions = {
   model: string;
   llmOnly: boolean;
   topK: number;
+  // TODO advanced filtering with DSL supporting operators $and, $or, $lt, $gt, $eq, $neq, $in, $nin
+  // For now, hardcode to matching the 'term' field of the metadata
+  filterTerm: string;
 };
 
 export async function query(vectorStore: VectorStore, options: QueryOptions) {
-  const { query, model, llmOnly, topK } = options;
+  const { query, model, llmOnly, topK, filterTerm } = options;
 
   const prompt = ['Answer the question based on the markdown context below.'];
 
   if (llmOnly) {
     console.log(`Querying ${model} without additional context`);
   } else {
-    const { results, context } = await getContext(vectorStore, query, topK);
+    const { results, context } = await getContext(vectorStore, query, topK, filterTerm);
 
     console.log(`Querying ${model} with additional context`);
     console.log(
@@ -43,12 +46,18 @@ export async function query(vectorStore: VectorStore, options: QueryOptions) {
   console.log(results[0].text?.trim());
 }
 
-async function getContext(vectorStore: VectorStore, query: string, topK: number) {
+async function getContext(
+  vectorStore: VectorStore,
+  query: string,
+  topK: number,
+  filterTerm: string
+) {
   const embedding = await createEmbedding({ input: query });
 
   const results = await vectorStore.query({
     topK,
     embedding: embedding.data[0].embedding,
+    filterTerm,
   });
 
   const context = results.map((result) => result.document.text).join('\n\n---\n\n');

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ export interface VectorizedDocument extends Document {
 export interface VectorQuery {
   topK: number;
   embedding: number[];
+  filterTerm: string;
 }
 
 export interface VectorQueryResult {

--- a/src/vector_stores/chroma.ts
+++ b/src/vector_stores/chroma.ts
@@ -88,6 +88,7 @@ export class Chroma implements VectorStore {
     const response = await collection.query({
       nResults: query.topK,
       queryEmbeddings: query.embedding,
+      where: query.filterTerm ? { term: { $eq: query.filterTerm } } : undefined,
     });
 
     const ids = response.ids[0];

--- a/src/vector_stores/pinecone.ts
+++ b/src/vector_stores/pinecone.ts
@@ -109,6 +109,7 @@ export class Pinecone implements VectorStore {
         vector: query.embedding,
         namespace: this.namespace,
         includeMetadata: true,
+        filter: query.filterTerm ? { term: { $eq: query.filterTerm } } : undefined,
       },
     });
 


### PR DESCRIPTION
Right now, the DSL is exact match only, and looks like this:
```
npm run query -- --store=chroma --query="Where is Patagonia?" --topK=5 --filterTerm=Santiago
```

Both Chroma and pinecone support this JSON query language that looks like this ([MQL](https://www.mongodb.com/docs/manual/reference/operator/query/) = Mongo Query Language):
```
$eq - Equal to (number, string, boolean)
$ne - Not equal to (number, string, boolean)
$gt - Greater than (number)
$gte - Greater than or equal to (number)
$lt - Less than (number)
$lte - Less than or equal to (number)
$in - In array (string or number)
$nin - Not in array (string or number)
```

I'm not sure if this is some kind of standard (feels like it). I think that a better interface is to support objects like this:
```json
{ "$and": [{ "genre": "comedy" }, { "genre": "drama" }] }
```

Here is Vec's implementation of the MQL. They recursively parse the JSON, then pipe it to their ORM (sqlalchemy) https://github.com/supabase/vecs/blob/main/src/vecs/collection.py#L707-L783